### PR TITLE
added new channel icon and made icons a bit bigger

### DIFF
--- a/telegram/app/qml/components/DialogsListItem.qml
+++ b/telegram/app/qml/components/DialogsListItem.qml
@@ -103,6 +103,11 @@ ListItem {
                             telegram: list_item.telegram,
                             dialog: list_item.dialog
                     });
+
+                    console.log("isChat: "+isChat)
+                    console.log("isChannel: "+isChannel)
+                    console.log("chat.megaGroup: "+chat.megaGroup)
+
                 }
             }
         ]
@@ -160,13 +165,26 @@ ListItem {
 
         Icon {
             id: contact_group_icon
-            visible: isChat || isChannel
+            visible: isChat || (isChannel && chat.megaGroup)
             name: "contact-group"
             anchors {
                 top: parent.top
                 bottom: parent.bottom
-                topMargin: units.dp(4)
-                bottomMargin: units.dp(4)
+                topMargin: units.dp(2)
+                bottomMargin: units.dp(2)
+            }
+            width: height
+        }
+
+        Icon {
+            id: contact_channel_icon
+            visible: isChannel && !chat.megaGroup
+            source: "qrc:/qml/files/broadcast.svg"
+            anchors {
+                top: parent.top
+                bottom: parent.bottom
+                topMargin: units.dp(2)
+                bottomMargin: units.dp(2)
             }
             width: height
         }

--- a/telegram/app/qml/files/broadcast.svg
+++ b/telegram/app/qml/files/broadcast.svg
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="96"
+   height="96"
+   id="svg4874"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   viewBox="0 0 96 96.000001"
+   sodipodi:docname="broadcast02.svg">
+  <defs
+     id="defs4876" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="10.976561"
+     inkscape:cx="23.641279"
+     inkscape:cy="24.012571"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     showborder="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:object-paths="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:object-nodes="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:snap-midpoints="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-center="true"
+     showguides="false"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5451"
+       empspacing="8" />
+    <sodipodi:guide
+       orientation="1,0"
+       position="8,-8.0000001"
+       id="guide4063" />
+    <sodipodi:guide
+       orientation="1,0"
+       position="4,-8.0000001"
+       id="guide4065" />
+    <sodipodi:guide
+       orientation="0,1"
+       position="-8,88.000001"
+       id="guide4067" />
+    <sodipodi:guide
+       orientation="0,1"
+       position="-8,92.000001"
+       id="guide4069" />
+    <sodipodi:guide
+       orientation="0,1"
+       position="104,4"
+       id="guide4071" />
+    <sodipodi:guide
+       orientation="0,1"
+       position="-5,8.0000001"
+       id="guide4073" />
+    <sodipodi:guide
+       orientation="1,0"
+       position="88,-8.0000001"
+       id="guide4077" />
+    <sodipodi:guide
+       orientation="0,1"
+       position="-8,84.000001"
+       id="guide4074" />
+    <sodipodi:guide
+       orientation="1,0"
+       position="12,-8.0000001"
+       id="guide4076" />
+    <sodipodi:guide
+       orientation="1,0"
+       position="84,-8.0000001"
+       id="guide4080" />
+    <sodipodi:guide
+       position="48,-8.0000001"
+       orientation="1,0"
+       id="guide4170" />
+    <sodipodi:guide
+       position="-8,48"
+       orientation="0,1"
+       id="guide4172" />
+    <sodipodi:guide
+       position="92,-8.0000001"
+       orientation="1,0"
+       id="guide4760" />
+    <sodipodi:guide
+       position="112,12"
+       orientation="0,1"
+       id="guide4154" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata4879">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(67.857146,-78.50504)">
+    <rect
+       transform="rotate(90)"
+       y="-28.142857"
+       x="78.505051"
+       height="96"
+       width="96"
+       id="rect4782"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:none;stroke-width:4;marker:none;enable-background:accumulate" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="M 64 16.003906 L 61.234375 17.152344 L 25.207031 32.097656 L 3.1972656 31.994141 L 2.6464844 33.123047 C 2.6464844 33.123047 0 38.653603 0 48.007812 C 0 57.362023 2.6484375 62.876953 2.6484375 62.876953 L 3.1933594 63.994141 L 8.734375 64.019531 C 13.987564 75.345546 15.003906 90.123047 15.003906 90.123047 L 15.121094 92 L 26 92 L 26 64.423828 L 64 79.978516 L 64 16.003906 z M 82.990234 16.646484 L 79.455078 20.181641 C 86.833511 27.560071 90.976562 37.56532 90.976562 48 C 90.976562 58.43468 86.833511 68.437966 79.455078 75.816406 L 82.990234 79.353516 C 91.304991 71.038756 95.976563 59.75884 95.976562 48 C 95.976562 36.24116 91.304991 24.96124 82.990234 16.646484 z M 60 21.994141 L 60 74.019531 L 26 60.101562 L 26 36.099609 L 60 21.994141 z M 73.107422 26.529297 L 69.572266 30.064453 C 74.329553 34.821743 77 41.27218 77 48 C 77 54.72782 74.329553 61.176314 69.572266 65.933594 L 73.107422 69.46875 C 78.801033 63.77514 82 56.05198 82 48 C 82 39.94802 78.801033 32.222907 73.107422 26.529297 z M 5.8613281 36.005859 L 22 36.082031 L 22 60.082031 L 5.8652344 60.005859 C 5.3440344 58.760539 4 55.187713 4 48.007812 C 4 40.843812 5.3364741 37.266399 5.8613281 36.005859 z M 13.132812 64.041016 L 22 64.082031 L 22 88 L 18.753906 88 C 18.570941 85.559064 17.627772 74.574963 13.132812 64.041016 z "
+       transform="translate(-67.857146,78.50504)"
+       id="path4180" />
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:15.99999905;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="rect4165"
+       width="96"
+       height="96"
+       x="-67.857147"
+       y="78.505035" />
+  </g>
+</svg>

--- a/telegram/app/telegram.qrc
+++ b/telegram/app/telegram.qrc
@@ -133,5 +133,6 @@
         <file>qml/InstallStickerDialog.qml</file>
         <file>qml/files/eyeWhite.svg</file>
         <file>qml/files/eye.svg</file>
+		<file>qml/files/broadcast.svg</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
the icons before the chat name are bigger (except ne muted one because it seems already big enough to me and also the secret chat) and there is the channel one (taken from the suru update https://bazaar.launchpad.net/~tiheum/ubuntu-themes/suru-update-201703/view/head:/suru-icons/actions/scalable/broadcast.svg ) 
![immagine](https://user-images.githubusercontent.com/28359593/35886975-212601d4-0b93-11e8-916f-1bd9f801ce50.png)
this in an example with all the icons visible
![immagine](https://user-images.githubusercontent.com/28359593/35887239-f4bd278e-0b93-11e8-8da3-16ced756154b.png)

